### PR TITLE
fix: coredata insecure value fixed

### DIFF
--- a/NearCatch/NearCatch.xcdatamodeld/NearCatch.xcdatamodel/contents
+++ b/NearCatch/NearCatch.xcdatamodeld/NearCatch.xcdatamodel/contents
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Keyword" representedClassName="Keyword" syncable="YES">
-        <attribute name="favorite" attributeType="Transformable" customClassName="[Int]"/>
+        <attribute name="favorite" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformerName" customClassName="[Int]"/>
     </entity>
     <entity name="Picture" representedClassName="Picture" syncable="YES">
-        <attribute name="content" attributeType="Transformable" valueTransformerName="" customClassName="UIImage"/>
+        <attribute name="content" attributeType="Transformable" valueTransformerName="UIImageTransformer" customClassName="UIImage"/>
     </entity>
     <entity name="Profile" representedClassName="Profile" syncable="YES" codeGenerationType="class">
         <attribute name="nickname" attributeType="String"/>
     </entity>
     <elements>
+        <element name="Keyword" positionX="-45" positionY="18" width="128" height="44"/>
         <element name="Picture" positionX="-54" positionY="18" width="128" height="44"/>
         <element name="Profile" positionX="-63" positionY="-18" width="128" height="44"/>
-        <element name="Keyword" positionX="-45" positionY="18" width="128" height="44"/>
     </elements>
 </model>


### PR DESCRIPTION
코어데이터 warning 수정했습니다.
Keyword.favorite is using a nil or insecure value transformer. Please switch to NSSecureUnarchiveFromDataTransformerName or a custom NSValueTransformer subclass of NSSecureUnarchiveFromDataTransformer [2]
--> 코어데이터를 transformable로 저장할때 transformer 지정 안한 경우에 발생